### PR TITLE
'Ingredients' & 'Employees' tab styling

### DIFF
--- a/src/components/List.css
+++ b/src/components/List.css
@@ -1,0 +1,9 @@
+.recipeList > button,
+.ingredientList > button {
+  margin-left: auto;
+}
+
+.recipeList,
+.ingredientList {
+  display: flex;
+}

--- a/src/components/List.css
+++ b/src/components/List.css
@@ -1,9 +1,0 @@
-.recipeList > button,
-.ingredientList > button {
-  margin-left: auto;
-}
-
-.recipeList,
-.ingredientList {
-  display: flex;
-}

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -1,5 +1,6 @@
 import React, { useRef } from "react";
 import useSimpleAuth from "../../hooks/ui/UseSimpleAuth";
+import { Button, Form, FormGroup, Label, Input } from "reactstrap";
 
 const Login = (props) => {
   const username = useRef();
@@ -21,31 +22,31 @@ const Login = (props) => {
 
   return (
     <main>
-      <form className="form--login" onSubmit={handleLogin}>
-        <h1 className="">Sign In</h1>
-        <fieldset>
-          <label htmlFor="inputUsername">Username </label>
-          <input
-            ref={username}
+      <Form className="loginRegister" onSubmit={handleLogin}>
+        <h1>Sign In</h1>
+        <FormGroup>
+          <Label htmlFor="inputUsername">Username </Label>
+          <Input
+            innerRef={username}
             type="username"
             className="form-control"
             required
             autoFocus
           />
-        </fieldset>
-        <fieldset>
-          <label htmlFor="inputPassword">Password </label>
-          <input
-            ref={password}
+        </FormGroup>
+        <FormGroup>
+          <Label htmlFor="inputPassword">Password </Label>
+          <Input
+            innerRef={password}
             type="password"
             className="form-control"
             required
           />
-        </fieldset>
-        <fieldset>
-          <button type="submit">Enter</button>
-        </fieldset>
-      </form>
+        </FormGroup>
+        <FormGroup>
+          <Button type="submit">Enter</Button>
+        </FormGroup>
+      </Form>
     </main>
   );
 };

--- a/src/components/auth/LoginRegister.css
+++ b/src/components/auth/LoginRegister.css
@@ -1,0 +1,3 @@
+.loginRegister {
+  width: 10rem;
+}

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -33,7 +33,7 @@ const Register = (props) => {
 
   return (
     <main>
-      <form className="form--login" onSubmit={handleRegister}>
+      <form className="loginRegister" onSubmit={handleRegister}>
         <h1 className="">Register to use PRIX</h1>
         <fieldset>
           <label htmlFor="userName">Username </label>

--- a/src/components/employees/EditEmployeeForm.js
+++ b/src/components/employees/EditEmployeeForm.js
@@ -61,7 +61,9 @@ const EditEmployeeForm = (props) => {
 
   return (
     <>
-      <Button onClick={toggle}>Edit Employee</Button>
+      <Button className="edit-btn" onClick={toggle}>
+        Edit Employee
+      </Button>
       <Modal isOpen={modal} toggle={toggle}>
         <ModalHeader toggle={toggle} close={closeBtn}>
           {props.user.first_name} {props.user.last_name}

--- a/src/components/employees/EditEmployeeForm.js
+++ b/src/components/employees/EditEmployeeForm.js
@@ -63,7 +63,7 @@ const EditEmployeeForm = (props) => {
               <Input
                 type="text"
                 innerRef={firstName}
-                defaultValue={props.employee.first_name}
+                defaultValue={props.user.first_name}
                 name="first-name"
                 required
                 autoFocus
@@ -73,7 +73,7 @@ const EditEmployeeForm = (props) => {
               <Label for="last-name">Last Name</Label>
               <Input
                 type="text"
-                defaultValue={props.employee.last_name}
+                defaultValue={props.user.last_name}
                 innerRef={lastName}
                 name="last-name"
                 required
@@ -83,7 +83,7 @@ const EditEmployeeForm = (props) => {
               <Label for="email">Email</Label>
               <Input
                 type="text"
-                defaultValue={props.employee.email}
+                defaultValue={props.user.email}
                 innerRef={email}
                 name="email"
                 required

--- a/src/components/employees/EditEmployeeForm.js
+++ b/src/components/employees/EditEmployeeForm.js
@@ -7,6 +7,7 @@ import {
   Label,
   Input,
   Modal,
+  ModalHeader,
   ModalBody,
 } from "reactstrap";
 
@@ -52,10 +53,19 @@ const EditEmployeeForm = (props) => {
     setModal(!modal);
   };
 
+  const closeBtn = (
+    <button className="close" onClick={toggle}>
+      &times;
+    </button>
+  );
+
   return (
     <>
       <Button onClick={toggle}>Edit Employee</Button>
       <Modal isOpen={modal} toggle={toggle}>
+        <ModalHeader toggle={toggle} close={closeBtn}>
+          {props.user.first_name} {props.user.last_name}
+        </ModalHeader>
         <ModalBody>
           <Form onSubmit={handleEditEmployee} id="edit-employee-form">
             <FormGroup>

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -1,19 +1,25 @@
 import React from "react";
+import EditEmployeeForm from "./EditEmployeeForm";
 
 const Employee = (props) => {
   return (
-    <section className="employee">
-      <div className="employee-firstName">
-        {props.employee.user.first_name}
-      </div>
-      <div className="employee-lastName">
-        {props.employee.user.last_name}
-      </div>
-      <div className="employee-isAdmin">
-        {props.employee.is_admin ? "Yes" : "No"}
-      </div>
-      <div className="employee-email">{props.employee.user.email}</div>
-    </section>
+    <tbody>
+      <tr>
+        <th scope="row">{props.employee.user.first_name}</th>
+        <td>{props.employee.user.last_name}</td>
+        <td>{props.employee.is_admin ? "Yes" : "No"}</td>
+        <td>{props.employee.user.email}</td>
+        <td>
+          <EditEmployeeForm
+            key={`button-${props.employee.id}`}
+            user={props.user}
+            employeeId={props.employee.id}
+            isAdmin={props.isAdmin}
+            getEmployees={props.getEmployees}
+          />
+        </td>
+      </tr>
+    </tbody>
   );
 };
 

--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -3,6 +3,7 @@ import Employee from "./Employee";
 import AddEmployeeForm from "./AddEmployeeForm";
 import EditEmployeeForm from "./EditEmployeeForm";
 import DataManager from "../../api/DataManager";
+// import "../List.css";
 
 const EmployeeList = (props) => {
   const [employees, setEmployees] = useState([]);

--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -3,6 +3,7 @@ import Employee from "./Employee";
 import AddEmployeeForm from "./AddEmployeeForm";
 import EditEmployeeForm from "./EditEmployeeForm";
 import DataManager from "../../api/DataManager";
+import { Table } from "reactstrap";
 // import "../List.css";
 
 const EmployeeList = (props) => {
@@ -19,18 +20,27 @@ const EmployeeList = (props) => {
   return (
     <article className="employeeList">
       <AddEmployeeForm {...props} getEmployees={getEmployees} />
-      {employees.map((employee) => (
-        <>
-          <Employee key={employee.id} employee={employee} />
-          <EditEmployeeForm
-            key={`button-${employee.id}`}
-            employee={employee.user}
+      <Table hover striped size="sm">
+        <thead>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Admin</th>
+            <th>Email</th>
+            <th></th>
+          </tr>
+        </thead>
+        {employees.map((employee) => (
+          <Employee
+            key={employee.id}
+            employee={employee}
+            user={employee.user}
             employeeId={employee.id}
             isAdmin={employee.is_admin}
             getEmployees={getEmployees}
           />
-        </>
-      ))}
+        ))}
+      </Table>
     </article>
   );
 };

--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -20,7 +20,7 @@ const EmployeeList = (props) => {
   return (
     <article className="employeeList">
       <AddEmployeeForm {...props} getEmployees={getEmployees} />
-      <Table hover bordered striped size="sm">
+      <Table hover bordered size="sm">
         <thead>
           <tr>
             <th>First Name</th>

--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -20,7 +20,7 @@ const EmployeeList = (props) => {
   return (
     <article className="employeeList">
       <AddEmployeeForm {...props} getEmployees={getEmployees} />
-      <Table hover striped size="sm">
+      <Table hover bordered striped size="sm">
         <thead>
           <tr>
             <th>First Name</th>

--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -1,10 +1,8 @@
 import React, { useEffect, useState } from "react";
 import Employee from "./Employee";
 import AddEmployeeForm from "./AddEmployeeForm";
-import EditEmployeeForm from "./EditEmployeeForm";
 import DataManager from "../../api/DataManager";
 import { Table } from "reactstrap";
-// import "../List.css";
 
 const EmployeeList = (props) => {
   const [employees, setEmployees] = useState([]);
@@ -19,7 +17,11 @@ const EmployeeList = (props) => {
 
   return (
     <article className="employeeList">
-      <AddEmployeeForm {...props} getEmployees={getEmployees} />
+      <AddEmployeeForm
+        className="add-btn"
+        {...props}
+        getEmployees={getEmployees}
+      />
       <Table hover bordered size="sm">
         <thead>
           <tr>

--- a/src/components/ingredients/EditIngredientForm.js
+++ b/src/components/ingredients/EditIngredientForm.js
@@ -83,7 +83,9 @@ const EditIngredientForm = (props) => {
 
   return (
     <>
-      <Button onClick={toggle}>Edit Ingredient</Button>
+      <Button className="edit-btn" onClick={toggle}>
+        Edit Ingredient
+      </Button>
       <Modal isOpen={modal} toggle={toggle}>
         <ModalHeader toggle={toggle} close={closeBtn}>
           {props.ingredient.name}
@@ -112,17 +114,14 @@ const EditIngredientForm = (props) => {
               <select id="ingredient-category" ref={ingredientCategory}>
                 <option
                   value={props.ingredientCategoryId}
-                  key={`ing-category--${props.ingredientCategoryId}`}
+                  key={props.ingredientCategoryId}
                 >
                   {props.ingredientCategory.name}
                 </option>
-                {ingredientCategories.map((category) => (
+                {ingredientCategories.map((category, idx) => (
                   <>
                     {props.ingredientCategory.name !== category.name ? (
-                      <option
-                        value={category.id}
-                        key={`ing-category--${category.id}`}
-                      >
+                      <option value={category.id} key={category.id}>
                         {category.name}
                       </option>
                     ) : null}
@@ -141,12 +140,12 @@ const EditIngredientForm = (props) => {
                 >
                   {props.measurementType.name}
                 </option>
-                {measurementTypes.map((type) => (
+                {measurementTypes.map((type, idx) => (
                   <>
                     {props.measurementType.name !== type.name ? (
                       <option
                         value={type.id}
-                        key={`measurement--${type.id}`}
+                        key={`measurement--${idx}`}
                       >
                         {type.name}
                       </option>

--- a/src/components/ingredients/EditIngredientForm.js
+++ b/src/components/ingredients/EditIngredientForm.js
@@ -12,7 +12,6 @@ const EditIngredientForm = (props) => {
   const purchaseQuantity = useRef();
   const purchasePrice = useRef();
 
-  console.log(ingredientCategory);
   const handleEditIngredient = (e) => {
     e.preventDefault();
 

--- a/src/components/ingredients/EditIngredientForm.js
+++ b/src/components/ingredients/EditIngredientForm.js
@@ -1,6 +1,12 @@
 import React, { useEffect, useRef, useState } from "react";
 import DataManager from "../../api/DataManager";
-import { Button, Form, Modal, ModalBody } from "reactstrap";
+import {
+  Button,
+  Form,
+  Modal,
+  ModalHeader,
+  ModalBody,
+} from "reactstrap";
 
 const EditIngredientForm = (props) => {
   const [modal, setModal] = useState(false);
@@ -57,6 +63,12 @@ const EditIngredientForm = (props) => {
     setModal(!modal);
   };
 
+  const closeBtn = (
+    <button className="close" onClick={toggle}>
+      &times;
+    </button>
+  );
+
   useEffect(() => {
     DataManager.getAll("measurementtype").then((allTypes) => {
       setMeasurementTypes(allTypes);
@@ -73,6 +85,9 @@ const EditIngredientForm = (props) => {
     <>
       <Button onClick={toggle}>Edit Ingredient</Button>
       <Modal isOpen={modal} toggle={toggle}>
+        <ModalHeader toggle={toggle} close={closeBtn}>
+          {props.ingredient.name}
+        </ModalHeader>
         <ModalBody>
           <Form
             onSubmit={handleEditIngredient}
@@ -141,7 +156,9 @@ const EditIngredientForm = (props) => {
               </select>
             </fieldset>
             <fieldset>
-              <label htmlFor="purchase-quantity">Quantity </label>
+              <label htmlFor="purchase-quantity">
+                Purchase Quantity{" "}
+              </label>
               <input
                 id="purchase-quantity"
                 ref={purchaseQuantity}
@@ -153,7 +170,7 @@ const EditIngredientForm = (props) => {
               />
             </fieldset>
             <fieldset>
-              <label htmlFor="purchase-price">Price </label>
+              <label htmlFor="purchase-price">Purchase Price </label>
               <input
                 id="purchase-price"
                 ref={purchasePrice}

--- a/src/components/ingredients/Ingredient.js
+++ b/src/components/ingredients/Ingredient.js
@@ -1,20 +1,46 @@
 import React from "react";
+import EditIngredientForm from "./EditIngredientForm";
 
 const Ingredient = (props) => {
   return (
-    <section className="ingredient">
-      <div className="ingredient-name">{props.ingredient.name}</div>
-      <div className="ingredient-category">
-        {props.ingredient.ingredient_category.name}
-      </div>
-      <div className="purchase-quantity">
-        {props.ingredient.purchase_quantity}{" "}
-        {props.ingredient.measurement_type.name}
-      </div>
-      <div className="purchase-price">
-        ${props.ingredient.purchase_price}
-      </div>
-    </section>
+    <tbody>
+      <tr>
+        <th scope="row">{props.ingredient.name}</th>
+        <td>{props.ingredient.ingredient_category.name}</td>
+        <td>
+          {props.ingredient.purchase_quantity}{" "}
+          {props.ingredient.measurement_type.name}
+        </td>
+        <td>${props.ingredient.purchase_price}</td>
+        <td>
+          <EditIngredientForm
+            key={`edit-ing--${props.idx}`}
+            ingredientCategory={props.ingredient.ingredient_category}
+            ingredientCategoryId={
+              props.ingredient.ingredient_category_id
+            }
+            measurementType={props.ingredient.measurement_type}
+            measurementTypeId={props.ingredient.measurement_type_id}
+            getIngredients={props.getIngredients}
+            ingredient={props.ingredient}
+          />
+        </td>
+      </tr>
+    </tbody>
+
+    // <section className="ingredient">
+    //   <div className="ingredient-name">{props.ingredient.name}</div>
+    //   <div className="ingredient-category">
+    //     {props.ingredient.ingredient_category.name}
+    //   </div>
+    //   <div className="purchase-quantity">
+    //     {props.ingredient.purchase_quantity}{" "}
+    //     {props.ingredient.measurement_type.name}
+    //   </div>
+    //   <div className="purchase-price">
+    //     ${props.ingredient.purchase_price}
+    //   </div>
+    // </section>
   );
 };
 

--- a/src/components/ingredients/Ingredient.js
+++ b/src/components/ingredients/Ingredient.js
@@ -14,7 +14,7 @@ const Ingredient = (props) => {
         <td>${props.ingredient.purchase_price}</td>
         <td>
           <EditIngredientForm
-            key={`edit-ing--${props.idx}`}
+            key={`edit-${props.ingredient.id}`}
             ingredientCategory={props.ingredient.ingredient_category}
             ingredientCategoryId={
               props.ingredient.ingredient_category_id
@@ -27,20 +27,6 @@ const Ingredient = (props) => {
         </td>
       </tr>
     </tbody>
-
-    // <section className="ingredient">
-    //   <div className="ingredient-name">{props.ingredient.name}</div>
-    //   <div className="ingredient-category">
-    //     {props.ingredient.ingredient_category.name}
-    //   </div>
-    //   <div className="purchase-quantity">
-    //     {props.ingredient.purchase_quantity}{" "}
-    //     {props.ingredient.measurement_type.name}
-    //   </div>
-    //   <div className="purchase-price">
-    //     ${props.ingredient.purchase_price}
-    //   </div>
-    // </section>
   );
 };
 

--- a/src/components/ingredients/IngredientList.js
+++ b/src/components/ingredients/IngredientList.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from "react";
 import Ingredient from "./Ingredient";
-import EditIngredientForm from "./EditIngredientForm";
 import AddIngredientForm from "./AddIngredientForm";
 import DataManager from "../../api/DataManager";
+import { Table } from "reactstrap";
 
 const IngredientList = (props) => {
   const [ingredients, setIngredients] = useState([]);
@@ -18,24 +18,29 @@ const IngredientList = (props) => {
   return (
     <article className="ingredientList">
       <AddIngredientForm {...props} getIngredients={getIngredients} />
-      {ingredients.map((ingredient, idx) => (
-        <>
+      <Table hover bordered size="sm">
+        <thead>
+          <tr>
+            <th>Product</th>
+            <th>Category</th>
+            <th>Purchase Quantity</th>
+            <th>Purchase Price</th>
+            <th></th>
+          </tr>
+        </thead>
+        {ingredients.map((ingredient, idx) => (
           <Ingredient
             key={`ingredient--${idx}`}
+            idx={idx}
             ingredient={ingredient}
-          />
-          <EditIngredientForm
-            {...props}
             ingredientCategory={ingredient.ingredient_category}
             ingredientCategoryId={ingredient.ingredient_category_id}
             measurementType={ingredient.measurement_type}
             measurementTypeId={ingredient.measurement_type_id}
             getIngredients={getIngredients}
-            key={`edit-ing--${idx}`}
-            ingredient={ingredient}
           />
-        </>
-      ))}
+        ))}
+      </Table>
     </article>
   );
 };

--- a/src/components/ingredients/IngredientList.js
+++ b/src/components/ingredients/IngredientList.js
@@ -17,7 +17,11 @@ const IngredientList = (props) => {
 
   return (
     <article className="ingredientList">
-      <AddIngredientForm {...props} getIngredients={getIngredients} />
+      <AddIngredientForm
+        className="add-btn"
+        {...props}
+        getIngredients={getIngredients}
+      />
       <Table hover bordered size="sm">
         <thead>
           <tr>
@@ -28,10 +32,9 @@ const IngredientList = (props) => {
             <th></th>
           </tr>
         </thead>
-        {ingredients.map((ingredient, idx) => (
+        {ingredients.map((ingredient) => (
           <Ingredient
-            key={`ingredient--${idx}`}
-            idx={idx}
+            key={ingredient.id}
             ingredient={ingredient}
             ingredientCategory={ingredient.ingredient_category}
             ingredientCategoryId={ingredient.ingredient_category_id}

--- a/src/components/nav/NavBar.css
+++ b/src/components/nav/NavBar.css
@@ -1,0 +1,26 @@
+.main-nav {
+  background-color: black;
+  height: 4rem;
+}
+
+.brand {
+  color: white;
+}
+
+.nav-link {
+  border: none;
+}
+
+.navs-link:visited,
+.navs-link:hover,
+.navs-link:link {
+  color: white;
+}
+
+.nav-item:first-of-type {
+  margin-left: auto;
+}
+
+.fakeLink {
+  background-color: black;
+}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -1,58 +1,47 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import useSimpleAuth from "../../hooks/ui/UseSimpleAuth";
+import { Nav, NavItem, NavLink, Button } from "reactstrap";
 
 const NavBar = (props) => {
   const { isAuthenticated, logout } = useSimpleAuth();
 
   return (
-    <nav>
-      <ul>
-        <li className="nav-item">
-          <Link className="nav-link" to="/ingredients">
-            Ingredients
-          </Link>
-        </li>
-        <li className="nav-link">
-          <Link className="nav-link" to="/recipes">
-            Recipes
-          </Link>
-        </li>
-        <li className="nav-link">
-          <Link className="nav-link" to="/employees">
-            Employees
-          </Link>
-        </li>
-        {isAuthenticated() ? (
-          <li className="nav-item">
-            <button
-              className="nav-link fakeLink"
-              onClick={() => {
-                logout();
-                props.history.push({
-                  pathname: "/login",
-                });
-              }}
-            >
-              Logout
-            </button>
-          </li>
-        ) : (
-          <>
-            <li className="nav-item">
-              <Link className="nav-link" to="/login">
-                Login
-              </Link>
-            </li>
-            <li className="nav-item">
-              <Link className="nav-link" to="/register">
-                Register
-              </Link>
-            </li>
-          </>
-        )}
-      </ul>
-    </nav>
+    <Nav tabs>
+      <NavItem>
+        <NavLink href="/ingredients">Ingredients</NavLink>
+      </NavItem>
+      <NavItem>
+        <NavLink href="/recipes">Recipes</NavLink>
+      </NavItem>
+      <NavItem>
+        <NavLink href="/employees">Employees</NavLink>
+      </NavItem>
+      {isAuthenticated() ? (
+        <NavItem>
+          <Button
+            className="nav-link fakeLink"
+            onClick={() => {
+              logout();
+              props.history.push({
+                pathname: "/login",
+              });
+            }}
+          >
+            Logout
+          </Button>
+        </NavItem>
+      ) : (
+        <>
+          <NavItem>
+            <Link href="/login">Login</Link>
+          </NavItem>
+          <NavItem>
+            <Link href="/register">Register</Link>
+          </NavItem>
+        </>
+      )}
+    </Nav>
   );
 };
 

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -34,10 +34,10 @@ const NavBar = (props) => {
       ) : (
         <>
           <NavItem>
-            <Link href="/login">Login</Link>
+            <NavLink href="/login">Login</NavLink>
           </NavItem>
           <NavItem>
-            <Link href="/register">Register</Link>
+            <NavLink href="/register">Register</NavLink>
           </NavItem>
         </>
       )}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -16,11 +16,11 @@ const NavBar = (props) => {
               Ingredients
             </NavLink>
           </NavItem>
-          {/* <NavItem>
+          <NavItem>
             <NavLink className="navs-link" href="/recipes">
               Recipes
             </NavLink>
-          </NavItem> */}
+          </NavItem>
           <NavItem>
             <NavLink className="navs-link" href="/employees">
               Employees

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -1,43 +1,56 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import useSimpleAuth from "../../hooks/ui/UseSimpleAuth";
 import { Nav, NavItem, NavLink, Button } from "reactstrap";
+import "./NavBar.css";
 
 const NavBar = (props) => {
   const { isAuthenticated, logout } = useSimpleAuth();
 
   return (
-    <Nav tabs>
-      <NavItem>
-        <NavLink href="/ingredients">Ingredients</NavLink>
-      </NavItem>
-      <NavItem>
-        <NavLink href="/recipes">Recipes</NavLink>
-      </NavItem>
-      <NavItem>
-        <NavLink href="/employees">Employees</NavLink>
-      </NavItem>
+    <Nav className="main-nav" tabs>
+      <h2 className="brand">PRIX</h2>
       {isAuthenticated() ? (
-        <NavItem>
-          <Button
-            className="nav-link fakeLink"
-            onClick={() => {
-              logout();
-              props.history.push({
-                pathname: "/login",
-              });
-            }}
-          >
-            Logout
-          </Button>
-        </NavItem>
+        <>
+          <NavItem>
+            <NavLink className="navs-link" href="/ingredients">
+              Ingredients
+            </NavLink>
+          </NavItem>
+          {/* <NavItem>
+            <NavLink className="navs-link" href="/recipes">
+              Recipes
+            </NavLink>
+          </NavItem> */}
+          <NavItem>
+            <NavLink className="navs-link" href="/employees">
+              Employees
+            </NavLink>
+          </NavItem>
+          <NavItem>
+            <Button
+              className="navs-link fakeLink"
+              onClick={() => {
+                logout();
+                props.history.push({
+                  pathname: "/login",
+                });
+              }}
+            >
+              Logout
+            </Button>
+          </NavItem>
+        </>
       ) : (
         <>
           <NavItem>
-            <NavLink href="/login">Login</NavLink>
+            <NavLink className="navs-link" href="/login">
+              Login
+            </NavLink>
           </NavItem>
           <NavItem>
-            <NavLink href="/register">Register</NavLink>
+            <NavLink className="navs-link" href="/register">
+              Register
+            </NavLink>
           </NavItem>
         </>
       )}


### PR DESCRIPTION
# Description
Changed the 'Ingredients' and 'Employees' tabs so that they display as a table and added the edit buttons to the table as well.

Fixes # (issue)
## Type of change
- [x] New styling

# Testing Instructions
Log in and go to both 'Ingredients' and 'Employees' tabs. The data should display as a table.
Ingredients' column labels: Product, Category, Purchase Price, Purchase Quantity
Employees' column labels: First Name, Last Name, Admin, Email

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works